### PR TITLE
fix(ci): mass-release fails loudly instead of silent Skipped (use github.event.inputs)

### DIFF
--- a/.github/workflows/mass-release.yml
+++ b/.github/workflows/mass-release.yml
@@ -35,11 +35,32 @@ env:
 jobs:
   mass-release:
     runs-on: ubuntu-latest
-    if: inputs.confirm == 'PUBLISH'
+    # Note: the confirm input is validated explicitly in the first step of this
+    # job, not via a job-level `if:`. A job-level `if: inputs.confirm == 'PUBLISH'`
+    # silently marks the run as "Skipped" when the input does not match, which
+    # is awful for debugging — you cannot tell whether the workflow refused you
+    # or never started. The step-based check below fails loud with a clear
+    # error message.
     permissions:
       contents: read
 
     steps:
+      - name: Validate inputs
+        env:
+          CONFIRM: ${{ github.event.inputs.confirm }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          INCLUDE_MCP: ${{ github.event.inputs.include_mcp }}
+        run: |
+          set -euo pipefail
+          echo "confirm=${CONFIRM:-<empty>}"
+          echo "dry_run=${DRY_RUN:-<empty>}"
+          echo "include_mcp=${INCLUDE_MCP:-<empty>}"
+          if [ "${CONFIRM:-}" != "PUBLISH" ]; then
+            echo "::error::The 'confirm' input must be exactly 'PUBLISH' (case-sensitive). Got '${CONFIRM:-<empty>}'."
+            exit 1
+          fi
+          echo "Confirm input OK."
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -81,7 +102,7 @@ jobs:
             echo "::endgroup::"
           done
 
-          if [ "${{ inputs.include_mcp }}" = "true" ]; then
+          if [ "${{ github.event.inputs.include_mcp }}" = "true" ]; then
             echo "::group::Pack mcp ($MCP_PROJECT)"
             dotnet pack "$MCP_PROJECT" --configuration "$CONFIGURATION" --output ./artifacts
             echo "::endgroup::"
@@ -98,7 +119,7 @@ jobs:
           if-no-files-found: error
 
       - name: Push to NuGet.org
-        if: inputs.dry_run != true
+        if: github.event.inputs.dry_run != 'true'
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
@@ -120,8 +141,8 @@ jobs:
           {
             echo "## Mass release summary"
             echo ""
-            echo "- Dry run: \`${{ inputs.dry_run }}\`"
-            echo "- Mcp included: \`${{ inputs.include_mcp }}\`"
+            echo "- Dry run: \`${{ github.event.inputs.dry_run }}\`"
+            echo "- Mcp included: \`${{ github.event.inputs.include_mcp }}\`"
             echo ""
             echo "### Packed artifacts"
             echo ""


### PR DESCRIPTION
## Problema

Você disparou `mass-release.yml` com `confirm: PUBLISH` (correto) e o GitHub Actions devolveu **Skipped** sem log nenhum, sem erro — impossível diagnosticar.

## Root cause

O guard estava no nível do job:

```yaml
jobs:
  mass-release:
    if: inputs.confirm == 'PUBLISH'
```

Pra `workflow_dispatch`, o contexto canônico é `github.event.inputs.*`. O `inputs.*` "unificado" foi introduzido depois mas é principalmente pensado pra `workflow_call` (reusable workflows); em expressões a nível de job em `workflow_dispatch` ele se comporta de forma inconsistente. Quando a expressão é falsy, o GitHub **simplesmente pula o job sem log** — pior UX possível pra debug.

## Fix

1. **Removo o guard de nível de job** e troco por um step `Validate inputs` que roda sempre, faz `echo` dos três inputs e dá `exit 1` com `::error::` claro se `confirm != "PUBLISH"`. Falha alta e visível em vez de Skipped fantasma.
2. **Troco todo `inputs.<x>` por `github.event.inputs.<x>`** no resto do workflow (gate do dry_run, `include_mcp`, summary). Inclui mudança sutil mas importante:
   - Antes: `if: inputs.dry_run != true` (comparação booleana)
   - Depois: `if: github.event.inputs.dry_run != 'true'` (comparação de string — `github.event.inputs.*` sempre vem como string, independente do `type: boolean` declarado).

## Como rodar depois do merge

1. Actions → "Mass Release" → **Run workflow** (a partir de `master`).
2. Inputs:
   - **confirm**: `PUBLISH` (literal, case-sensitive)
   - **include_mcp**: deixado em branco/false
   - **dry_run**: marcado (true) — pra primeira passada
3. Aguardar conclusão. Logs do step `Validate inputs` vão mostrar exatamente o que o GitHub Actions recebeu.
4. Confirmado o dry-run, re-dispatch com **dry_run: false** pra publicar.

## Test plan

- [ ] Após merge, rodar `mass-release.yml` em dry-run com `confirm: PUBLISH` — esperar conclusão verde, sem Skipped.
- [ ] Rodar com `confirm: publish` (lowercase) — esperar falha **alta** com mensagem `"The 'confirm' input must be exactly 'PUBLISH'..."` em vez de Skipped silencioso.
- [ ] Re-rodar dry-run com `confirm: PUBLISH` e `dry_run: false` — esperar push pro NuGet.org dos 23 pacotes novos (Data 6.3.0 + 22 alinhados); EF 6.3.0 é no-op via `--skip-duplicate`.

https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py)_