### PR TITLE
fix(api-dto): import Dto.Shared.projitems so the package actually packs

### DIFF
--- a/Codout.Framework.Api.Dto/Codout.Framework.Api.Dto.csproj
+++ b/Codout.Framework.Api.Dto/Codout.Framework.Api.Dto.csproj
@@ -14,4 +14,9 @@
     <Folder Include="Default\" />
   </ItemGroup>
 
+  <!-- Same shared-source import pattern used by Codout.Framework.Application and
+       Codout.Framework.Api.Client. Without it this project has zero .cs files,
+       MSBuild produces no assembly, and `dotnet pack` fails with NU5026. -->
+  <Import Project="..\Codout.Framework.Dto.Shared\Codout.Framework.Dto.projitems" Label="Shared" />
+
 </Project>


### PR DESCRIPTION
## Problema

`mass-release.yml` falhou no pack do `api-dto`:

```
error NU5026: The file '.../Codout.Framework.Api.Dto/bin/Release/netstandard2.1/Codout.Framework.Api.Dto.dll'
to be packed was not found on disk.
```

## Root cause

A pasta `Codout.Framework.Api.Dto/` tem **só o `.csproj`** — zero arquivos `.cs`. Os tipos compartilhados do DTO (`Dto`, `IDto`, `EntityDto<T>`, `IEntityDto<T>`) moram em `Codout.Framework.Dto.Shared/` como um Shared Project (`.shproj` + `.projitems`), e cada consumer puxa via `<Import>` no csproj.

Confirmação olhando os outros consumidores:

```bash
$ grep "Import Project" Codout.Framework.Application/*.csproj Codout.Framework.Api.Client/*.csproj
Codout.Framework.Application/...csproj:  <Import Project="..\Codout.Framework.Dto.Shared\Codout.Framework.Dto.projitems" Label="Shared" />
Codout.Framework.Api.Client/...csproj:    <Import Project="..\Codout.Framework.Dto.Shared\Codout.Framework.Dto.projitems" Label="Shared" />
```

`Codout.Framework.Api.Dto.csproj` simplesmente **não tinha** essa linha. Build não gerava DLL → pack não tinha o que empacotar → `NU5026`.

Confirmei que os outros 3 csproj que aparecem "vazios" no diretório raiz (`Common`, `Domain`, `Mailer`) **não** estão nesta situação — todos têm `.cs` em subpastas e o SDK pega via glob implícito.

## Fix

Uma linha no `Codout.Framework.Api.Dto.csproj`:

```xml
<Import Project="..\Codout.Framework.Dto.Shared\Codout.Framework.Dto.projitems" Label="Shared" />
```

Mais um comentário explicando por quê, pra próximo desenvolvedor não remover por engano.

## Versão

**Sem bump**. O `6.3.0` do `api-dto` nunca foi efetivamente publicado (pack falhou, nupkg não foi gerado, nada subiu pro NuGet). O slot 6.3.0 continua livre — este PR só faz o pacote ser produzível pela primeira vez.

## Sequência depois do merge

1. Merge deste PR.
2. Actions → "Mass Release" → **Run workflow** novamente:
   - `confirm`: `PUBLISH`
   - `include_mcp`: desmarcado
   - `dry_run`: marcado (primeira passada)
3. Esperar todos os 24 packs concluírem (api-dto agora deve passar).
4. Re-dispatch com `dry_run` desmarcado pra publicar.

## Test plan

- [ ] Confirmar que `dotnet pack Codout.Framework.Api.Dto/Codout.Framework.Api.Dto.csproj` produz `.nupkg` sem erro
- [ ] Após merge, dry-run do `mass-release.yml` chega ao final sem NU5026
- [ ] Artifact `codout-framework-all-nupkg` tem 24 `.nupkg` (incluindo `Codout.Framework.Api.Dto.6.3.0.nupkg`)
- [ ] Run de publicação real sobe os 23 novos (EF 6.3.0 vira no-op via `--skip-duplicate`)

https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py)_