### PR TITLE
ci: split build and pack with --verbosity normal to surface api-dto build errors

### DIFF
--- a/.github/workflows/mass-release.yml
+++ b/.github/workflows/mass-release.yml
@@ -93,18 +93,41 @@ jobs:
           set -euo pipefail
           mkdir -p ./artifacts
 
+          # Build and pack each project in two explicit steps with --verbosity
+          # normal, so any build error (missing source, broken Import, etc.) is
+          # surfaced in the logs instead of being swallowed by `dotnet pack`'s
+          # implicit-build behavior.
+          #
           # Out-of-solution projects (Cosmos, DocumentDB, etc.) need their own
-          # restore/build, so we deliberately do NOT pass --no-build here.
+          # restore + build here.
           for pkg in $(jq -r 'keys[]' "$MAPPING"); do
             project=$(jq -r --arg p "$pkg" '.[$p]' "$MAPPING")
+            echo "::group::Build $pkg ($project)"
+            dotnet build "$project" \
+              --configuration "$CONFIGURATION" \
+              --verbosity normal
+            echo "::endgroup::"
+
             echo "::group::Pack $pkg ($project)"
-            dotnet pack "$project" --configuration "$CONFIGURATION" --output ./artifacts
+            dotnet pack "$project" \
+              --configuration "$CONFIGURATION" \
+              --no-build \
+              --output ./artifacts
             echo "::endgroup::"
           done
 
           if [ "${{ github.event.inputs.include_mcp }}" = "true" ]; then
+            echo "::group::Build mcp ($MCP_PROJECT)"
+            dotnet build "$MCP_PROJECT" \
+              --configuration "$CONFIGURATION" \
+              --verbosity normal
+            echo "::endgroup::"
+
             echo "::group::Pack mcp ($MCP_PROJECT)"
-            dotnet pack "$MCP_PROJECT" --configuration "$CONFIGURATION" --output ./artifacts
+            dotnet pack "$MCP_PROJECT" \
+              --configuration "$CONFIGURATION" \
+              --no-build \
+              --output ./artifacts
             echo "::endgroup::"
           fi
 


### PR DESCRIPTION
## Problema persistente

PR #14 adicionou o `<Import>` esperado em `Codout.Framework.Api.Dto.csproj`, mas o `mass-release.yml` ainda falha no mesmo step com **NU5026** (DLL não encontrada). O output que vejo dos logs é só:

```
Pack api-dto (Codout.Framework.Api.Dto/Codout.Framework.Api.Dto.csproj)
    Determining projects to restore...
    Restored .../Codout.Framework.Api.Dto.csproj (in 72 ms).
  Error: ...NU5026: The file '.../Codout.Framework.Api.Dto.dll' to be packed was not found on disk.
```

**Sem log de build.** Não dá pra distinguir entre:

1. O `<Import>` não está adicionando os Compile items (build deveria falhar com CS2008 "no inputs").
2. Build aconteceu mas não emitiu DLL (improvável mas possível).
3. Build foi pulado por algum motivo (cache, NoBuild implícito, etc.).

## Fix do diagnóstico

Separo `dotnet build` e `dotnet pack` no step, com `--verbosity normal` no build:

```bash
dotnet build "$project" --configuration Release --verbosity normal
dotnet pack  "$project" --configuration Release --no-build --output ./artifacts
```

Vantagens:

- **Build errors aparecem explícitos no log** (CS2008, MSB3030, etc.).
- **Pack só roda se build passou** — separação clara entre os dois.
- Se o problema for Compile items vazios, vai aparecer literalmente "Sources: 0 file(s)" ou erro de "no inputs".
- Os outros 23 pacotes continuam funcionando idênticos.

## Como usar

1. **Merge este PR.**
2. **Re-dispatch** `mass-release.yml` com `confirm: PUBLISH`, `dry_run: true`.
3. Quando falhar no api-dto (provável), copia o log do step `Build api-dto` aqui — agora vai ter informação suficiente pra eu identificar a causa raiz.
4. Com root cause em mãos, abro PR de fix definitivo.

## Test plan

- [ ] YAML válido (já validado localmente com `yaml.safe_load`).
- [ ] Dry-run pós-merge mostra logs de build com `--verbosity normal` pros 24 pacotes.
- [ ] Logs de api-dto revelam o que está realmente acontecendo no build (Compile items, csc invocation, etc.).

## Não muda

- Lógica de validação de inputs (PR #13).
- Filtros de mcp / dry_run.
- Path do publish step.

https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py)_