### PR TITLE
ci: split build and pack in release.yml (mirror mass-release fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,15 +108,25 @@ jobs:
       - name: Test (solution)
         run: dotnet test Codout.Framework.sln --configuration "$CONFIGURATION" --no-build --verbosity normal
 
+      - name: Build (target project)
+        run: |
+          # Build the target project explicitly with --verbosity normal. The
+          # solution build above does not cover out-of-solution packages
+          # (Cosmos, DocumentDB, etc.) and may leave the target unbuilt anyway,
+          # so we build it here and pack with --no-build below. Splitting
+          # build and pack also keeps build errors visible — relying on
+          # `dotnet pack`'s implicit build can silently swallow failures (see
+          # the api-dto NU5026 incident that motivated this pattern in
+          # mass-release.yml).
+          dotnet build "${{ steps.resolve.outputs.project }}" \
+            --configuration "$CONFIGURATION" \
+            --verbosity normal
+
       - name: Pack
         run: |
           set -euo pipefail
           VERSION="${{ steps.resolve.outputs.version }}"
           PROJECT="${{ steps.resolve.outputs.project }}"
-          # Pack performs its own restore/build for the target. Some packages
-          # (Cosmos, DocumentDB, etc.) are not part of Codout.Framework.sln, so
-          # we deliberately do NOT pass --no-build here.
-          #
           # IMPORTANT: when overriding the package version via workflow_dispatch,
           # use ONLY -p:PackageVersion=. Passing -p:Version= cascades to every
           # project in the build graph (including ProjectReferences), which
@@ -124,11 +134,11 @@ jobs:
           # produces broken packages. -p:PackageVersion only affects the
           # outgoing package and leaves ProjectReference resolution alone.
           if [ -n "$VERSION" ]; then
-            dotnet pack "$PROJECT" --configuration "$CONFIGURATION" \
+            dotnet pack "$PROJECT" --configuration "$CONFIGURATION" --no-build \
               -p:PackageVersion="$VERSION" \
               --output ./artifacts
           else
-            dotnet pack "$PROJECT" --configuration "$CONFIGURATION" \
+            dotnet pack "$PROJECT" --configuration "$CONFIGURATION" --no-build \
               --output ./artifacts
           fi
           ls -la ./artifacts


### PR DESCRIPTION
## Contexto

PR #15 separou `dotnet build` de `dotnet pack --no-build` no `mass-release.yml` e isso resolveu o sintoma NU5026 do `api-dto` — provavelmente uma interação ruim entre o `dotnet pack` (com build implícito) e o `GeneratePackageOnBuild=true` do `Directory.Build.props`. O `release.yml` (tag-driven, um pacote por vez) tem o mesmo padrão compactado e quebraria com o mesmo sintoma na próxima tag de algum pacote que dependa de shared project ou outro edge case parecido.

## Mudança

Aplica a mesma forma no `release.yml`:

- **Novo step "Build (target project)"** roda `dotnet build` com `--verbosity normal` (build errors ficam visíveis).
- **Step "Pack"** agora usa `--no-build` (build já rodou) e só empacota o output existente.
- `-p:PackageVersion=` continua sendo o **único** override de versão no pack — `-p:Version=` permanece banido (cascateia pra `ProjectReference`).

## Efeito

- `ef-v6.3.0`, único release tag-driven até agora, foi publicado bem. Esse PR é **defense-in-depth** pra próxima tag.
- Outros 23 pacotes em 6.3.0 foram publicados via `mass-release.yml` (já com o padrão correto).
- `mcp-release.yml` já tinha build + pack separados — não precisa mexer.

## Test plan

- [ ] YAML válido (validado localmente com `yaml.safe_load`).
- [ ] Próxima tag `<short>-v<X.Y.Z>` que disparar `release.yml` mostra logs explícitos de build.
- [ ] Caso edge equivalente ao api-dto (shared project, csproj sem .cs direto) **não** dispara NU5026 silencioso.

https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxScBEvdKkRwGvJTgK5Py)_